### PR TITLE
Set cucumber version to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "parallel": "CONFIG_FILE=parallel ./scripts/cucumber-runner.js features/single.feature"
   },
   "devDependencies": {
-    "cucumber": "*",
+    "cucumber": "1.3.3",
     "cucumber-assert": "*",
     "selenium-webdriver": "^2.53.2"
   },


### PR DESCRIPTION
By default currently version 2.x is installed which is not compatible with the project configuration and gives the following error message:

```
Scenario: Can find search results - features/single.feature:3
Step: When I type query as "BrowserStack" - features/single.feature:4
Message:
Undefined. Implement with the following snippet:
```